### PR TITLE
a callback to push config changes to a remote repository

### DIFF
--- a/lib/oxidized/hook/githubrepo.rb
+++ b/lib/oxidized/hook/githubrepo.rb
@@ -1,0 +1,16 @@
+class GithubRepo < Oxidized::Hook
+  def validate_cfg!
+    cfg.has_key?('remote_repo') or raise 'remote_repo is required'
+  end
+
+  def run_hook(ctx)
+    credentials =  Rugged::Credentials::SshKeyFromAgent.new(username: 'git')
+    repo = Rugged::Repository.new(Oxidized::CFG.output.git.repo)
+    log "Pushing local repository(#{repo.path})..."
+    remote = repo.remotes['origin'] || repo.remotes.create('origin', cfg.remote_repo)
+    log "to remote: #{remote.url}"
+    remote.push(['refs/heads/master'], credentials: credentials)
+  rescue Exception => e
+    log e.backtrace.join('\n')
+  end
+end

--- a/lib/oxidized/hook/githubrepo.rb
+++ b/lib/oxidized/hook/githubrepo.rb
@@ -10,7 +10,5 @@ class GithubRepo < Oxidized::Hook
     remote = repo.remotes['origin'] || repo.remotes.create('origin', cfg.remote_repo)
     log "to remote: #{remote.url}"
     remote.push(['refs/heads/master'], credentials: credentials)
-  rescue Exception => e
-    log e.backtrace.join('\n')
   end
 end

--- a/lib/oxidized/hook/githubrepo.rb
+++ b/lib/oxidized/hook/githubrepo.rb
@@ -1,6 +1,6 @@
 class GithubRepo < Oxidized::Hook
   def validate_cfg!
-    cfg.has_key?('remote_repo') or raise 'remote_repo is required'
+    cfg.has_key?('remote_repo') or raise KeyError, 'remote_repo is required'
   end
 
   def run_hook(ctx)

--- a/lib/oxidized/hook/githubrepo.rb
+++ b/lib/oxidized/hook/githubrepo.rb
@@ -5,7 +5,7 @@ class GithubRepo < Oxidized::Hook
 
   def run_hook(ctx)
     credentials =  Rugged::Credentials::SshKeyFromAgent.new(username: 'git')
-    repo = Rugged::Repository.new(Oxidized::CFG.output.git.repo)
+    repo = Rugged::Repository.new(Oxidized.config.output.git.repo)
     log "Pushing local repository(#{repo.path})..."
     remote = repo.remotes['origin'] || repo.remotes.create('origin', cfg.remote_repo)
     log "to remote: #{remote.url}"

--- a/spec/githubrepo_spec.rb
+++ b/spec/githubrepo_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+require 'rugged'
+require 'oxidized/hook/githubrepo'
+
+describe Oxidized::Node do
+  before(:each) do
+    asetus = Asetus.new
+    asetus.cfg.output.git.repo = 'foo.git'
+    Oxidized.stubs(:asetus).returns(asetus)
+    repo = mock()
+    remote = mock()
+    remote.expects(:url).returns('github.com/foo.git')
+    remote.expects(:push).returns(true)
+    repo.expects(:remotes).returns({'origin' => remote})
+    repo.expects(:path).returns('foo.git')
+    Rugged::Repository.expects(:new).with('foo.git').returns(repo)
+  end
+
+  describe "#run_hook" do
+    it "will push to the remote repository" do
+      gr = GithubRepo.new
+      gr.run_hook(nil).must_equal true
+    end
+  end
+end


### PR DESCRIPTION
To register the callback following lines must be added to oxidized's config file.

```
hooks:
  github_repo_hook:
    type: githubrepo
    events: [post_store]
    remote_repo: <remote repository url>
```

After this whenever a new commit made in the local git repository GithubRepo hook will push it to the remote repository. The assumption is ssh access to the remote repository is configured in the host machine.

@Shopify/traffic 
